### PR TITLE
fix(Task.all): fixed typings for unary tuples and arrays

### DIFF
--- a/src/task/task-all.ts
+++ b/src/task/task-all.ts
@@ -12,7 +12,8 @@ declare module './task' {
         function all <T1, T2, T3, T4, E1, E2, E3, E4> (tasks: [Task<T1, E1>, Task<T2, E2>, Task<T3, E3>, Task<T4, E4>]): Task<[T1, T2, T3, T4], E1 | E2 | E3 | E4>;
         function all <T1, T2, T3, E1, E2, E3> (tasks: [Task<T1, E1>, Task<T2, E2>, Task<T3, E3>]): Task<[T1, T2, T3], E1 | E2 | E3>;
         function all <T1, T2, E1, E2> (tasks: [Task<T1, E1>, Task<T2, E2>]): Task<[T1, T2], E1 | E2>;
-        function all <T, E> (tasks: Array<Task<T, E>>): Task<[T], E>;
+        function all <T1, E1> (tasks: [Task<T1, E1>]): Task<[T1], E1>;
+        function all <T, E> (tasks: Array<Task<T, E>>): Task<T[], E>;
     }
 }
 

--- a/test/types/basic-usage.ts
+++ b/test/types/basic-usage.ts
@@ -58,8 +58,7 @@ const t3 = Task
         ? Task.resolve(-1)
         : Task.reject(err)
 );
-t3; // $ExpectType Task<number, Error | UncaughtError>
-
+t3; // $ExpectType Task<number, UncaughtError | Error>
 
 // Task forces you to check for errors, so when you fork the
 // first callback is the error and the second callback is the success.

--- a/test/types/operators/all.ts
+++ b/test/types/operators/all.ts
@@ -1,11 +1,26 @@
 import { Task } from '@ts-task/task';
 
+/************************************************
+ * Tasks with an unary tuple
+ ***********************************************/
+
+// Given a basic Task
+const t = Task.resolve(9); // $ExpectType Task<number, never>
+
+// ...Task.all called with an unary tuple of that Task will give us a Task of an
+// unary tuple with the result
+Task.all([t]); // $ExpectType Task<[number], never>
+
+/************************************************
+ * Tasks with a n-ary tuple
+ ***********************************************/
+
 // Given three basic tasks
 const t1 = Task.resolve(9);                     // $ExpectType Task<number, never>
 const t2 = Task.resolve<string, string>('foo'); // $ExpectType Task<string, string>
 const t3 = Task.resolve<boolean, Error>(true);  // $ExpectType Task<boolean, Error>
 
-// Task.all will infer the success type T as a tuple of its arguments' success values,
+// ...Task.all will infer the success type T as a tuple of its arguments' success values,
 // and the error type E as any of the individual errors
 Task.all([t1, t2, t3]); // $ExpectType Task<[number, string, boolean], string | Error>
 
@@ -13,3 +28,17 @@ Task.all([t1, t2, t3]); // $ExpectType Task<[number, string, boolean], string | 
 // const allT = [t1, t2, t3];
 
 // Task.all(allT);
+
+/************************************************
+ * Tasks with an array (not tuple)
+ ***********************************************/
+
+// Given an array of tasks:
+const arrOfTasks = [1, 2, 3] // $ExpectType Task<number, never>[]
+	.map(x =>
+		Task.resolve(x)
+	)
+;
+
+// ...Task.all called with that array will give as a Task of an array:
+Task.all(arrOfTasks); // $ExpectType Task<number[], never>


### PR DESCRIPTION
# Description

Fixes #3. `Task.all` was badly typed for _arrays_ (not _tuples_). It used to infer `Task<[T], E>` instead of `Task<T[], E>`.
