### PR TITLE
fix(Task.all): fixes Task.all when called with an empty array (closes…

### DIFF
--- a/src/task/task-all.test.ts
+++ b/src/task/task-all.test.ts
@@ -115,5 +115,21 @@ describe('Task', () => {
                 jestAssertUntypedNeverCalled(cb)
             );
         });
+
+        it('should resolve to an empty array if it\'s called with an empty array', cb => {
+            // GIVEN: an empty array
+            const arr: Task<number, never>[] = [];
+
+            // WHEN: calling `Task.all` with that array
+            const tAll = Task.all(arr);
+
+            // THEN: the resulted Task is resolved with an empty array.
+            tAll.fork(
+                jestAssertNever(cb),
+                assertFork(cb, result => {
+                    expect(result).toEqual([]);
+                })
+            );
+        });
     });
 });

--- a/src/task/task-all.ts
+++ b/src/task/task-all.ts
@@ -26,6 +26,11 @@ Task.all = function (tasks: any): any {
     let resolvedQty = 0;
 
     return new Task((outerResolve, outerReject) => {
+        // If the tasks array is empty, resolve with an empty array.
+        if (!tasks.length) {
+            outerResolve([]);
+        }
+
         tasks.forEach((aTask: any, index: number) => {
             aTask
                 .fork((err: any) => {


### PR DESCRIPTION
… #5). (#6)